### PR TITLE
Sql tuples

### DIFF
--- a/lib/grim/reaper.ex
+++ b/lib/grim/reaper.ex
@@ -131,21 +131,14 @@ defmodule Grim.Reaper do
     %{state | cold_polls: cold_polls}
   end
 
-  # query is an actual ectto query
-  def reap(%{query: query, ttl: ttl, repo: repo, cold_polls: cold_polls} = state) do
-    date =
-      DateTime.utc_now()
-      |> DateTime.add(-ttl, :second)
-      |> DateTime.truncate(:second)
-      |> DateTime.to_naive()
-
+  # query is an actual ecto query
+  def reap(%{query: query, repo: repo, cold_polls: cold_polls} = state) do
     {_, schema} = query.from.source
 
     primary_keys = schema.__schema__(:primary_key)
 
     id_maps =
       query
-      |> where([record], record.inserted_at < ^date)
       |> select([record], map(record, ^primary_keys))
       |> repo.all()
 

--- a/lib/grim/reaper_supervisor.ex
+++ b/lib/grim/reaper_supervisor.ex
@@ -16,6 +16,7 @@ defmodule Grim.ReaperSupervisor do
     Supervisor.init(children, strategy: :one_for_one)
   end
 
+  # converts different init options into child specs
   defp transform_child(child, repo) when is_atom(child) do
     {Reaper, [query: child, repo: repo]}
   end

--- a/test/grim_test.exs
+++ b/test/grim_test.exs
@@ -118,7 +118,7 @@ defmodule GrimTest do
 
     {:ok, pid} = GenServer.start(Reaper, opts)
 
-    %{cold_polls: 1} = :sys.get_state(pid) |> IO.inspect()
+    %{cold_polls: 1} = :sys.get_state(pid)
 
     count =
       Soul


### PR DESCRIPTION
This fixes the issue with composite key collision by building a raw sql query with tuple strings instead of checking each keys existence in different lists. Ecto does not support composite key tuples in a delete.